### PR TITLE
Update write-i18n-loaders.js to return promises appropriately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 * Updated fs-extra dependencies
 * Updated ESLint to v6
 * Replaced Object.assign syntax with Object spread syntax
+* Return the promise created by lazy loading
 
 ### Removed
 * Removed DangerJS integration

--- a/lib/write-i18n-loaders.js
+++ b/lib/write-i18n-loaders.js
@@ -28,7 +28,7 @@ const createTranslationLoader = (loaderName, locale, format) => {
     return (
       `const ${loaderName} = (callback, scope) =>
    import( /* webpackChunkName: "${locale}-translations" */ '${locale}.js')
-     .then((module) => { callback.call(scope, module); })
+     .then((module) => { callback.call(scope, module);})
      .catch(error => console.log('An error occurred while loading ${locale}.js' + "\\n" + error));\n
 `
     );

--- a/lib/write-i18n-loaders.js
+++ b/lib/write-i18n-loaders.js
@@ -28,7 +28,10 @@ const createTranslationLoader = (loaderName, locale, format) => {
     return (
       `const ${loaderName} = (callback, scope) =>
    import( /* webpackChunkName: "${locale}-translations" */ '${locale}.js')
-     .then((module) => { callback.call(scope, module);})
+     .then((module) => { 
+       callback.call(scope, module);
+       return Promise.resolve(module);
+     })
      .catch(error => console.log('An error occurred while loading ${locale}.js' + "\\n" + error));\n
 `
     );
@@ -40,6 +43,7 @@ const createTranslationLoader = (loaderName, locale, format) => {
     // eslint-disable-next-line
     var i18n = require('./${locale}.js');
     callback.call(scope, i18n);
+    return i18n;
   }, '${locale}-translations');
 };\n
 `

--- a/lib/write-i18n-loaders.js
+++ b/lib/write-i18n-loaders.js
@@ -28,10 +28,7 @@ const createTranslationLoader = (loaderName, locale, format) => {
     return (
       `const ${loaderName} = (callback, scope) =>
    import( /* webpackChunkName: "${locale}-translations" */ '${locale}.js')
-     .then((module) => { 
-       callback.call(scope, module);
-       return Promise.resolve(module);
-     })
+     .then((module) => { callback.call(scope, module); })
      .catch(error => console.log('An error occurred while loading ${locale}.js' + "\\n" + error));\n
 `
     );

--- a/tests/jest/__snapshots__/write-i18n-loaders.test.js.snap
+++ b/tests/jest/__snapshots__/write-i18n-loaders.test.js.snap
@@ -24,6 +24,7 @@ var loadCyTranslations = function loadCyTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./cy.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'cy-translations');
 };
 
@@ -74,6 +75,7 @@ var loadEnTranslations = function loadEnTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./en.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'en-translations');
 };
 
@@ -82,6 +84,7 @@ var loadEnUSTranslations = function loadEnUSTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./en-US.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'en-US-translations');
 };
 
@@ -90,6 +93,7 @@ var loadEsTranslations = function loadEsTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./es.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'es-translations');
 };
 
@@ -181,6 +185,7 @@ var loadCyTranslations = function loadCyTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./cy.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'cy-translations');
 };
 
@@ -231,6 +236,7 @@ var loadEnTranslations = function loadEnTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./en.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'en-translations');
 };
 
@@ -239,6 +245,7 @@ var loadEnUSTranslations = function loadEnUSTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./en-US.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'en-US-translations');
 };
 
@@ -247,6 +254,7 @@ var loadEsTranslations = function loadEsTranslations(callback, scope) {
     // eslint-disable-next-line
     var i18n = require('./es.js');
     callback.call(scope, i18n);
+    return i18n;
   }, 'es-translations');
 };
 


### PR DESCRIPTION
Update write-i18n-loaders.js to return promises appropriately.  Not returning anything is an anti-pattern (http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it) Fixes #10 