### PR TITLE
Add Peer Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     "glob": "^7.1.1",
     "lodash.startcase": "^4.4.0"
   },
+  "peerDependencies": {
+    "intl": "^1.2.5",
+    "react-intl": "^2.8.0"
+  },
   "devDependencies": {
     "eslint": "^6.1.0",
     "eslint-config-terra": "^3.0.0",


### PR DESCRIPTION
Aggregate-translations generate files the import content from [`intl`](https://github.com/cerner/terra-aggregate-translations/blob/master/lib/write-i18n-loaders.js#L10) and [`react-intl`](https://github.com/cerner/terra-aggregate-translations/blob/master/lib/generate-translation-file.js#L26). Adding these peer dependencies to be transparent about the supported versions.

### Summary
Issue highlighted by: https://github.com/cerner/terra-aggregate-translations/issues/15