### PR TITLE
Update aggregate translations to return the list of supported locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Changed
+* Update aggregate translations function to return the list of supported locales
 
 1.5.0 - (January 28, 2020)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,7 +4,9 @@ Cerner Corporation
 - Brett Jankord [@bjankord]
 - Emily Rohrbough [@emilyrohrbough]
 - Adam Parker [@amichaelparker]
+- Stephen Esser [@StephenEsser]
 
 [@bjankord]: https://github.com/bjankord
 [@emilyrohrbough]: https://github.com/emilyrohrbough
 [@amichaelparker]: https://github.com/amichaelparker
+[@StephenEsser]: https://github.com/StephenEsser

--- a/lib/aggregate-translations.js
+++ b/lib/aggregate-translations.js
@@ -48,6 +48,13 @@ const defaults = (options = {}) => {
 /**
  * Aggregates translation files and initializes the appropriate internationalization loaders.
  * @param {Object} options - The aggregation options.
+ * @param {string} options.baseDir - Directory to search from and to prepend to the output directory.
+ * @param {string|string[]} options.directories - Translation directory regex pattern(s) to glob, in addition to the default search patterns.
+ * @param {FileSystem} options.fileSystem - The filesystem to use to write the translation and loader files.
+ * @param {string[]} options.locales - The list of locale codes to aggregate.
+ * @param {string} options.outputDir - Output directory for the translation and loader files.
+ * @param {string|string[]} options.excludes - Translation directory regex pattern(s) to glob exclude from the search patterns.
+ * @param {string} options.format - The format of syntax to output the translations with. Possible values are 'es5' and 'es6'.
  * @returns {array} - An array of supported locales.
  */
 const aggregatedTranslations = (options) => {

--- a/lib/aggregate-translations.js
+++ b/lib/aggregate-translations.js
@@ -45,6 +45,11 @@ const defaults = (options = {}) => {
   return defaultConfig;
 };
 
+/**
+ * Aggregates translation files and initializes the appropriate internationalization loaders.
+ * @param {Object} options - The aggregation options.
+ * @returns {array} - An array of supported locales.
+ */
 const aggregatedTranslations = (options) => {
   const {
     baseDir, directories, fileSystem, locales, outputDir, excludes, format,
@@ -76,6 +81,8 @@ const aggregatedTranslations = (options) => {
 
   // Write intl and translations loaders for the specified locales
   writeI18nLoaders(locales, fileSystem, outputDirectory, format);
+
+  return locales;
 };
 
 module.exports = aggregatedTranslations;

--- a/tests/jest/aggregate-translations.test.js
+++ b/tests/jest/aggregate-translations.test.js
@@ -38,11 +38,11 @@ describe('aggregate-translations', () => {
   });
 
   it('aggregates on the default search patterns', () => {
-    aggregateTranslations();
+    const supportedLocales = aggregateTranslations();
 
     expect(globSpy).toHaveBeenCalledTimes(numOfDefaultSearchPatterns);
-    // expect(searchedDirectories).toEqual(expect.arrayContaining(defaultSearchPatterns(process.cwd())));
     expect(searchedDirectories).toEqual(expect.arrayContaining(defaultSearchPatterns));
+    expect(supportedLocales).toEqual(i18nSupportedLocales);
   });
 
   it('aggregates on the default search patterns and custom directory patterns', () => {
@@ -98,15 +98,16 @@ describe('aggregate-translations', () => {
     expect(writtenFilePaths.length).toEqual(numSupportedLocales + 2);
   });
 
-  it('aggregates on the specfied locales', () => {
+  it('aggregates on the specified locales', () => {
     const translationsFiles = [
       expect.stringContaining(`aggregated-translations${path.sep}en.js`),
     ];
 
-    aggregateTranslations({ locales: ['en'] });
+    const supportedLocales = aggregateTranslations({ locales: ['en'] });
 
     expect(writtenFilePaths).toEqual(expect.arrayContaining(translationsFiles));
     expect(writtenFilePaths.length).toEqual(3);
+    expect(supportedLocales).toEqual(['en']);
   });
 
   it('always aggregates on en locale even if not specified', () => {
@@ -115,10 +116,11 @@ describe('aggregate-translations', () => {
       `${process.cwd()}${path.sep}aggregated-translations${path.sep}es.js`,
     ];
 
-    aggregateTranslations({ locales: ['es'] });
+    const supportedLocales = aggregateTranslations({ locales: ['es'] });
 
     expect(writtenFilePaths).toEqual(expect.arrayContaining(translationsFiles));
     expect(writtenFilePaths.length).toEqual(4);
+    expect(supportedLocales).toEqual(['es', 'en']);
   });
 
   it('writes the intl and translations loaders', () => {


### PR DESCRIPTION
### Summary
<!-- Summarize the contents of the code changes. Tag any open issues you believe to be resolved by this pull request. -->

This PR updates the aggregateTranslations function to return the list of supported locales that were interpreted from the configuration options.

 ### Additional Details
<!-- If you have anything else that you think may be relevant to this issue, list it here. Additional information can help us better understand your changes and speed up the review process. -->

The supported locale list can be supplied through the environment CLI, the terra-18n-config file, or from the default fallback strategy. This updates terra-aggregate-translations to be the "source of truth" of which locales the script has successfully generated locale messages and loaders for.

Here are the anticipated changes for consuming this functionality within terra-toolkit:

https://github.com/cerner/terra-toolkit/compare/supported-locales

Resolves #18

 @cerner/terra